### PR TITLE
feat: add simple compile_commands.json generation

### DIFF
--- a/cpp/extension.bzl
+++ b/cpp/extension.bzl
@@ -1,9 +1,11 @@
-load("//cpp:repositories.bzl", "download_llvm")
+load("//cpp:repositories.bzl", "download_llvm", "setup_tools")
 
 def _init_toolchain(ctx):
     for mod in ctx.modules:
         for llvm in mod.tags.llvm:
             download_llvm(ctx, llvm.name, llvm.version)
+        for tools in mod.tags.tools:
+            setup_tools(ctx, tools.name)
 
 _llvm = tag_class(
     attrs = {
@@ -12,7 +14,13 @@ _llvm = tag_class(
     },
 )
 
+_tools = tag_class(
+    attrs = {
+        "name": attr.string(),
+    }
+)
+
 cpp = module_extension(
     implementation = _init_toolchain,
-    tag_classes = {"llvm": _llvm},
+    tag_classes = {"llvm": _llvm, "tools": _tools},
 )

--- a/cpp/private/refresh_compile_commands.py
+++ b/cpp/private/refresh_compile_commands.py
@@ -1,0 +1,55 @@
+import subprocess
+import re
+import os
+import json
+
+
+def get_bazel_root():
+    info = subprocess.run(["bazel info"], shell=True, capture_output=True, text=True).stderr
+    return re.search(r"The pertinent workspace directory is: \'(.*)\'", info).group(1)
+
+def parse_actions(actions):
+    actions = actions.split("\n\n")
+
+    mappings = []
+
+    for action in actions:
+        if action == "":
+            continue
+        #print(action)
+        #print(re.search(r"Inputs: \[(.*)\]", action))
+        sources = []
+        for src in re.search(r"Inputs: \[(.*)\]", action).group(1).split(","):
+            if src.endswith('.cpp') or src.endswith('.c'):
+                sources.append(src.strip())
+        prefix = "Command Line: (exec "
+        command_line = action[action.find(prefix) + len(prefix):]
+        command_line = command_line[:command_line.find(")\n")]
+        command_line = command_line.replace("\\\n", "")
+
+        for src in sources:
+            command_line = command_line.replace(src, "")
+
+        command_line = command_line.split()
+
+        for src in sources:
+            mappings.append({"file": src, "arguments": command_line})
+
+    return mappings
+
+
+def save_compile_commands(mappings):
+    compile_commands = []
+
+    for m in mappings:
+        compile_commands.append({"directory": os.getcwd(), "file": m['file'], "arguments": m['arguments']})
+
+    with open('compile_commands.json', 'w', encoding='utf-8') as f:
+        json.dump(compile_commands, f, indent=2)
+
+
+base_path = get_bazel_root()
+os.chdir(base_path)
+actions = subprocess.run(["bazel aquery 'mnemonic(\"CppCompile\", (inputs(\".*cpp\", //...)))'"], shell=True, capture_output=True, text=True).stdout
+mappings = parse_actions(actions)
+save_compile_commands(mappings)

--- a/cpp/private/tools.BUILD
+++ b/cpp/private/tools.BUILD
@@ -1,0 +1,5 @@
+load("//:tools_rules.bzl", "refresh_compile_commands")
+
+refresh_compile_commands(
+    name = "refresh_compile_commands"
+)

--- a/cpp/private/tools_rules.bzl
+++ b/cpp/private/tools_rules.bzl
@@ -1,0 +1,9 @@
+def refresh_compile_commands(name):
+    native.py_binary(
+        name = name,
+        main = "refresh_compile_commands.py",
+        srcs = [
+            "refresh_compile_commands.py",
+        ],
+        imports = [''],
+    )

--- a/cpp/repositories.bzl
+++ b/cpp/repositories.bzl
@@ -37,3 +37,22 @@ def download_llvm(mctx, repo_name, version):
         sha256 = clang_repo[version]["sha256"],
         build_file = "//cpp/private:llvm.BUILD",
     )
+
+def _tools_impl(rctx):
+    rctx.symlink(Label("//cpp/private:refresh_compile_commands.py"), "refresh_compile_commands.py")
+    # rctx.symlink("//cpp/private:tools.BUILD", "BUILD.bazel")
+    rctx.symlink(Label("//cpp/private:tools_rules.bzl"), "tools_rules.bzl")
+    build = rctx.read(Label("//cpp/private:tools.BUILD"))
+    rctx.file("WORKSPACE", executable=False)
+    rctx.file("BUILD", content=build)
+
+_tools = repository_rule(
+    implementation=_tools_impl,
+    configure=True,
+    # local=True,
+)
+
+def setup_tools(mctx, repo_name):
+    _tools(
+        name = repo_name,
+    )

--- a/integration_tests/.gitignore
+++ b/integration_tests/.gitignore
@@ -1,0 +1,2 @@
+*.lock
+compile_commands.json

--- a/integration_tests/toolchains/BUILD.bazel
+++ b/integration_tests/toolchains/BUILD.bazel
@@ -13,5 +13,8 @@ cc_library(
 cc_binary(
     name = "test",
     srcs = ["src/main.cpp"],
-    deps = [":foo"],
+    deps = [
+        ":foo",
+        "//lib2",
+    ],
 )

--- a/integration_tests/toolchains/MODULE.bazel
+++ b/integration_tests/toolchains/MODULE.bazel
@@ -14,4 +14,7 @@ cpp.llvm(
     name = "llvm-17",
     version = "17.0.6",
 )
-use_repo(cpp, "llvm-17")
+cpp.tools(
+    name = "cpp_tools",
+)
+use_repo(cpp, "cpp_tools", "llvm-17")

--- a/integration_tests/toolchains/lib2/BUILD.bazel
+++ b/integration_tests/toolchains/lib2/BUILD.bazel
@@ -1,0 +1,5 @@
+cc_library(
+    name = "lib2",
+    srcs = ["foo.cpp"],
+    visibility = ["//visibility:public"],
+)

--- a/integration_tests/toolchains/test_linux.sh
+++ b/integration_tests/toolchains/test_linux.sh
@@ -4,6 +4,8 @@ set -eu
 
 bazel build //...
 bazel run //:test
+bazel run @cpp_tools//:refresh_compile_commands
+test -f "compile_commands.json"
 
 bazel run --crosstool_top=@llvm-17//:toolchain //:test
 bazel run --crosstool_top=@llvm-17//:toolchain -c dbg //:test


### PR DESCRIPTION
This implementation is oversimplified on purpose. The proper implementation would use aspects and build command line arguments from features and flags, and be able to integrate with various tools or IDEs.