### PR TITLE
fix: use github mirror to build gcc

### DIFF
--- a/.github/workflows/gcc.yaml
+++ b/.github/workflows/gcc.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          repository: "gcc.gnu.org/git/gcc.git"
+          repository: "gcc-mirror/gcc"
           ref: release/${{ inputs.gcc_release }}
       - name: Build and install
         env:

--- a/.github/workflows/gcc.yaml
+++ b/.github/workflows/gcc.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: "gcc-mirror/gcc"
-          ref: release/${{ inputs.gcc_release }}
+          ref: releases/${{ inputs.gcc_release }}
       - name: Build and install
         env:
           CXXFLAGS: -w


### PR DESCRIPTION
GitHub Actions do not allow checkout from other sources