### PR TITLE
chore: improve GCC packaging

### DIFF
--- a/.github/workflows/gcc.yaml
+++ b/.github/workflows/gcc.yaml
@@ -31,16 +31,12 @@ jobs:
             make -j4
             make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-stdlib install-strip-target-libstdc++-v3
             make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-stdlib install-strip-target-libgcc
-            # make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-binutils install-strip-binutils
-            # make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-ld install-strip-ld
             make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-openmp install-strip-target-libgomp
             make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64 install-strip
 
             cd install
 
             tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64-stdlib.tar.zst ${{ inputs.gcc_release }}-linux-x86_64-stdlib
-            # tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64-binutils.tar.zst ${{ inputs.gcc_release }}-linux-x86_64-binutils
-            # tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64-ld.tar.zst ${{ inputs.gcc_release }}-linux-x86_64-ld
             tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64-openmp.tar.zst ${{ inputs.gcc_release }}-linux-x86_64-openmp
             tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64.tar.zst ${{ inputs.gcc_release }}-linux-x86_64
       - name: Upload artifact
@@ -60,8 +56,6 @@ jobs:
             touch RELASE.txt
             sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64.tar.zst >> RELEASE.txt
             sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-stdlib.tar.zst >> RELEASE.txt
-            # sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-binutils.tar.zst >> RELEASE.txt
-            # sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-ld.tar.zst >> RELEASE.txt
             sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-openmp.tar.zst >> RELEASE.txt
         - name: Create release
           uses: softprops/action-gh-release@v1

--- a/.github/workflows/gcc.yaml
+++ b/.github/workflows/gcc.yaml
@@ -31,16 +31,16 @@ jobs:
             make -j4
             make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-stdlib install-strip-target-libstdc++-v3
             make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-stdlib install-strip-target-libgcc
-            make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-binutils install-strip-binutils
-            make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-ld install-strip-ld
+            # make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-binutils install-strip-binutils
+            # make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-ld install-strip-ld
             make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-openmp install-strip-target-libgomp
             make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64 install-strip
 
             cd install
 
             tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64-stdlib.tar.zst ${{ inputs.gcc_release }}-linux-x86_64-stdlib
-            tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64-binutils.tar.zst ${{ inputs.gcc_release }}-linux-x86_64-binutils
-            tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64-ld.tar.zst ${{ inputs.gcc_release }}-linux-x86_64-ld
+            # tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64-binutils.tar.zst ${{ inputs.gcc_release }}-linux-x86_64-binutils
+            # tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64-ld.tar.zst ${{ inputs.gcc_release }}-linux-x86_64-ld
             tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64-openmp.tar.zst ${{ inputs.gcc_release }}-linux-x86_64-openmp
             tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64.tar.zst ${{ inputs.gcc_release }}-linux-x86_64
       - name: Upload artifact
@@ -60,8 +60,8 @@ jobs:
             touch RELASE.txt
             sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64.tar.zst >> RELEASE.txt
             sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-stdlib.tar.zst >> RELEASE.txt
-            sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-binutils.tar.zst >> RELEASE.txt
-            sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-ld.tar.zst >> RELEASE.txt
+            # sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-binutils.tar.zst >> RELEASE.txt
+            # sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-ld.tar.zst >> RELEASE.txt
             sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-openmp.tar.zst >> RELEASE.txt
         - name: Create release
           uses: softprops/action-gh-release@v1
@@ -74,6 +74,4 @@ jobs:
             files: |
               linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64.tar.zst
               linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-stdlib.tar.zst
-              linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-binutils.tar.zst
-              linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-ld.tar.zst
               linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-openmp.tar.zst

--- a/.github/workflows/gcc.yaml
+++ b/.github/workflows/gcc.yaml
@@ -27,17 +27,26 @@ jobs:
             ./configure --with-static-standard-libraries \
                 --enable-gold --enable-languages=c,c++,lto \
                 --enable-lto --host=x86_64-pc-linux-gnu \
-                --with-isl --with-zstd --prefix=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64
-            make -j2
-            make install
+                --with-isl --with-zstd --prefix=/
+            make -j4
+            make DESTDIR=install/${{ inputs.gcc_release }}-linux-x86_64-stdlib install-strip-target-libstdc++-v3
+            make DESTDIR=install/${{ inputs.gcc_release }}-linux-x86_64-stdlib install-strip-target-libgcc
+            make DESTDIR=install/${{ inputs.gcc_release }}-linux-x86_64-binutils install-strip-binutils
+            make DESTDIR=install/${{ inputs.gcc_release }}-linux-x86_64-ld install-strip-ld
+            make DESTDIR=install/${{ inputs.gcc_release }}-linux-x86_64-openmp install-strip-target-libgomp
+            make DESTDIR=install/${{ inputs.gcc_release }}-linux-x86_64 install-strip
 
             cd install
 
+            tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64-stdlib.tar.zst ${{ inputs.gcc_release }}-linux-x86_64-stdlib
+            tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64-binutils.tar.zst ${{ inputs.gcc_release }}-linux-x86_64-binutils
+            tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64-ld.tar.zst ${{ inputs.gcc_release }}-linux-x86_64-ld
+            tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64-openmp.tar.zst ${{ inputs.gcc_release }}-linux-x86_64-openmp
             tar --zstd -cf ${{ inputs.gcc_release }}-linux-x86_64.tar.zst ${{ inputs.gcc_release }}-linux-x86_64
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
-          path: install/${{ inputs.gcc_release }}-linux-x86_64.tar.zst
+          path: install/${{ inputs.gcc_release }}-linux-x86_64*.tar.zst
           name: linux-x86_64-toolchain
 
   publish_release:
@@ -50,6 +59,10 @@ jobs:
           run: |
             touch RELASE.txt
             sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64.tar.zst >> RELEASE.txt
+            sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-stdlib.tar.zst >> RELEASE.txt
+            sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-binutils.tar.zst >> RELEASE.txt
+            sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-ld.tar.zst >> RELEASE.txt
+            sha256sum linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-openmp.tar.zst >> RELEASE.txt
         - name: Create release
           uses: softprops/action-gh-release@v1
           with:
@@ -60,3 +73,7 @@ jobs:
             prerelease: true
             files: |
               linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64.tar.zst
+              linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-stdlib.tar.zst
+              linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-binutils.tar.zst
+              linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-ld.tar.zst
+              linux-x86_64-toolchain/${{ inputs.gcc_release }}-linux-x86_64-openmp.tar.zst

--- a/.github/workflows/gcc.yaml
+++ b/.github/workflows/gcc.yaml
@@ -23,18 +23,18 @@ jobs:
           CXXFLAGS: -w
           CFLAGS: -w
         run: |
-            mkdir -p install/${{ inputs.gcc_release }}-linux-x86_64
+            mkdir -p install
             ./configure --with-static-standard-libraries \
                 --enable-gold --enable-languages=c,c++,lto \
                 --enable-lto --host=x86_64-pc-linux-gnu \
                 --with-isl --with-zstd --prefix=/
             make -j4
-            make DESTDIR=install/${{ inputs.gcc_release }}-linux-x86_64-stdlib install-strip-target-libstdc++-v3
-            make DESTDIR=install/${{ inputs.gcc_release }}-linux-x86_64-stdlib install-strip-target-libgcc
-            make DESTDIR=install/${{ inputs.gcc_release }}-linux-x86_64-binutils install-strip-binutils
-            make DESTDIR=install/${{ inputs.gcc_release }}-linux-x86_64-ld install-strip-ld
-            make DESTDIR=install/${{ inputs.gcc_release }}-linux-x86_64-openmp install-strip-target-libgomp
-            make DESTDIR=install/${{ inputs.gcc_release }}-linux-x86_64 install-strip
+            make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-stdlib install-strip-target-libstdc++-v3
+            make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-stdlib install-strip-target-libgcc
+            make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-binutils install-strip-binutils
+            make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-ld install-strip-ld
+            make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64-openmp install-strip-target-libgomp
+            make DESTDIR=$PWD/install/${{ inputs.gcc_release }}-linux-x86_64 install-strip
 
             cd install
 


### PR DESCRIPTION
Split GCC into multiple packages to allow one to obtain stdlib or OpenMP separately.